### PR TITLE
Fix streamlit experimental_rerun attribute error

### DIFF
--- a/tool_using_agent.py
+++ b/tool_using_agent.py
@@ -393,7 +393,7 @@ def main():
                             st.session_state.pending_code = msg["code"]
                             st.session_state.pending_should_plot = bool(msg.get("should_plot", False))
                             st.session_state.pending_query = msg.get("query", "")
-                            st.experimental_rerun()
+                            st.rerun()
 
         # If a file is loaded, allow code generation and edit-before-run
         if file:
@@ -476,12 +476,12 @@ def main():
                     st.session_state.pending_code = None
                     st.session_state.pending_should_plot = False
                     st.session_state.pending_query = ""
-                    st.experimental_rerun()
+                    st.rerun()
                 elif cancel_clicked:
                     st.session_state.pending_code = None
                     st.session_state.pending_should_plot = False
                     st.session_state.pending_query = ""
-                    st.experimental_rerun()
+                    st.rerun()
 
             # Standard chat input -> generate code only (do not auto-execute)
             if user_q := st.chat_input("Ask about your data…"):
@@ -492,7 +492,7 @@ def main():
                 st.session_state.pending_code = code
                 st.session_state.pending_should_plot = should_plot_flag
                 st.session_state.pending_query = user_q
-                st.experimental_rerun()
+                st.rerun()
 
     with st.sidebar:
         st.subheader("🧠 Agent Memory")


### PR DESCRIPTION
Replace `st.experimental_rerun()` with `st.rerun()` to fix `AttributeError` due to Streamlit API changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-4109f3ce-808a-48b5-bbbf-68ec4c0063b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4109f3ce-808a-48b5-bbbf-68ec4c0063b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

